### PR TITLE
Add XelPool

### DIFF
--- a/pool_templates/xelpool.json
+++ b/pool_templates/xelpool.json
@@ -1,0 +1,41 @@
+[
+  {
+    "pool": {
+      "name": "XelPool.com",
+      "url": "https://xelpool.com",
+      "fee": 0.9,
+      "type": "PPLNS"
+    }
+  },
+  {
+    "coin": "XEL",
+    "servers": [
+      {
+        "geo": "Auto Getwork",
+        "urls": [
+          "auto.getwork.xelpool.com:2086"
+        ]
+      },
+      {
+        "geo": "Europe Getwork",
+        "urls": [
+          "de.getwork.xelpool.com:2086"
+        ]
+      },
+      {
+        "geo": "USA Getwork",
+        "urls": [
+          "us.getwork.xelpool.com:2086"
+        ]
+      }
+    ],
+    "miners": {
+      "onezerominer": {
+        "url": "%URL%",
+        "pass": "%WORKER_NAME%",
+        "template": "%WAL%",
+        "user_config": ""
+      }
+    }
+  }
+]


### PR DESCRIPTION
XelPool is the first xelis mining pool to have ever launched, and it has been running since April 30, 2024 (shortly after the XELIS launch).

https://xelpool.com/